### PR TITLE
- SoundstripeAudioProvider support added

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ imglyConfig {
     }
 }
 
-def MIN_LY_IMG_ANDROID_SDK_PLUGIN_VERSION = "10.4.1"
+def MIN_LY_IMG_ANDROID_SDK_PLUGIN_VERSION = "10.6.0"
 
 task checkVersion {
     if (imglyConfig.convertToVersionNumber(imglyConfig.getVersion()) < imglyConfig.convertToVersionNumber(MIN_LY_IMG_ANDROID_SDK_PLUGIN_VERSION)) {
@@ -73,5 +73,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "ly.img.android.sdk.ui.mobile_ui:soundstripe:$imglyConfig.version"
     compileOnly "ly.img.android.sdk:serializer:$imglyConfig.version"
 }

--- a/android/src/main/kotlin/ly/img/flutter/imgly_sdk/FlutterIMGLY.kt
+++ b/android/src/main/kotlin/ly/img/flutter/imgly_sdk/FlutterIMGLY.kt
@@ -13,6 +13,7 @@ import ly.img.android.pesdk.backend.decoder.ImageSource
 import ly.img.android.pesdk.backend.model.state.manager.SettingsList
 import ly.img.android.pesdk.backend.model.state.manager.StateHandler
 import ly.img.android.pesdk.backend.model.state.manager.configure
+import ly.img.android.pesdk.soundstripe.model.state.SoundstripeSettings
 import ly.img.android.pesdk.ui.activity.EditorActivity
 import ly.img.android.pesdk.ui.activity.EditorBuilder
 import ly.img.android.pesdk.ui.model.state.UiConfigTheme
@@ -48,6 +49,9 @@ open class FlutterIMGLY: FlutterPlugin, MethodChannel.MethodCallHandler, Activit
 
   /** The currently used *Configuration*. */
   var currentConfig: Configuration? = null
+
+  /** The *Configuration* for SoundStripe provider */
+  var soundstripeSettings: SoundstripeSettings? = null
 
   /** IMGLY constants for the plugin use. */
   object IMGLYConstants {
@@ -122,6 +126,9 @@ open class FlutterIMGLY: FlutterPlugin, MethodChannel.MethodCallHandler, Activit
    * @param settingsList The *SettingsList* which configures the editor.
    */
   fun startEditor(settingsList: SettingsList, resultID: Int, activity: Class<out EditorActivity>) {
+
+    applyAudioProviders(settingsList, currentConfig)
+
     val currentActivity = this.currentActivity ?: throw RuntimeException("Can't start the Editor because there is no current activity")
     currentEditorUID = UUID.randomUUID().toString()
     MainThreadRunnable {
@@ -222,6 +229,43 @@ open class FlutterIMGLY: FlutterPlugin, MethodChannel.MethodCallHandler, Activit
    */
   open fun present(asset: String, config: HashMap<String, Any>?, serialization: String?) { }
 
+  open fun applyAudioProviders(settingsList: SettingsList, config: Configuration?) {
+    if(config != null && soundstripeSettings != null) {
+      settingsList.configure<SoundstripeSettings> { settings ->
+        settings.proxySourceUri = soundstripeSettings?.proxySourceUri
+        soundstripeSettings?.proxyHeader?.forEach { header ->
+          if(header.value != null) {
+            settings.addHeader(header.key, header.value!!)
+          }
+        }
+      }
+      //If audio providers are set then ignore any AudioClip configuration
+      config.audio = null
+
+      config.applyOn(settingsList)
+    }
+  }
+  open fun resolveAudioProviders(confs: MutableMap<String, Any>) {
+    try {
+      val audioProvidersListConf: List<HashMap<String, Any>>? = confs["audioProviders"] as? List<HashMap<String, Any>>
+      audioProvidersListConf?.forEach { providerConf ->
+        when(providerConf["identifier"]) {
+          "soundstripe" -> {
+            val baseURL = providerConf["baseURL"] as? String
+            val headers: HashMap<String, String>? = providerConf["headers"] as? HashMap<String, String>
+            if(baseURL != null) {
+              soundstripeSettings = SoundstripeSettings()
+              soundstripeSettings?.proxySourceUri = baseURL
+              headers?.forEach {
+                soundstripeSettings?.addHeader(it.key, it.value)
+              }
+            }
+          }
+        }
+      }
+    } catch (_: Exception) {}
+  }
+
   /**
    * Resolves the nested assets from a configuration map.
    *
@@ -229,6 +273,10 @@ open class FlutterIMGLY: FlutterPlugin, MethodChannel.MethodCallHandler, Activit
    * @return The resolved configuration as a *MutableHashMap<String, Any>*.
    */
   fun resolveAssets(source: MutableMap<String, Any>) : MutableMap<String, Any> {
+
+    // Resolve the audio providers.
+    resolveAudioProviders(source)
+
     // Resolve the audio clips.
     val audioCategoryKeyPath = "audio.categories"
     val audioCategoryResolvingKeyPaths = listOf("thumbnailURI")

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.5.32'
-    ext.pesdk_version = '10.4.1'
+    ext.pesdk_version = '10.6.0'
 
     repositories {
         google()

--- a/ios/Classes/FlutterIMGLY.swift
+++ b/ios/Classes/FlutterIMGLY.swift
@@ -189,11 +189,20 @@ open class FlutterIMGLY: NSObject {
             }
 
             let toolbarMode = updatedDictionary.value(forKeyPath: "toolbarMode", defaultValue: nil) as? String
-
+            let audioProviders = self.audioProviders(configurationData: updatedDictionary)
+            
             configuration = Configuration(builder: { (builder) in
                 builder.assetCatalog = assetCatalog
                 do {
                     try builder.configure(from: updatedDictionary)
+                    if(!audioProviders.isEmpty) {
+                        
+                        if(!self.hasAudioClipCategories(configurationData: updatedDictionary)) {
+                            // This is a workaround to avoid an empty SoundstripeCategory being added by default.
+                            builder.assetCatalog.audioClips = []
+                        }
+                        builder.assetCatalog.audioClips.append(contentsOf: audioProviders)
+                    }
                 } catch let error {
                     self.result?(FlutterError(code: "Configuration could not be applied.", message: "The provided configuration is invalid. For futher information see the error attached in the details.", details: "ERROR:\(error.localizedDescription)"))
                     self.result = nil
@@ -232,6 +241,38 @@ open class FlutterIMGLY: NSObject {
                 self.result = nil
             }
         }
+    }
+    
+    private func audioProviders(configurationData: IMGLYDictionary) -> [AudioProviderCategory] {
+        var providers: [AudioProviderCategory] = []
+        
+        let audioProvidersListConf = configurationData.value(forKeyPath: "audioProviders", defaultValue: nil) as? [Dictionary<String, Any>]
+        
+        if(audioProvidersListConf != nil) {
+            audioProvidersListConf?.forEach({ providerConf in
+                switch (providerConf.value(forKeyPath: "identifier", defaultValue: nil) as? String) {
+                    case "soundstripe":
+                        var soundstripeProvider: SoundstripeAudioProvider?
+                        let baseURL = providerConf.value(forKeyPath: "baseURL", defaultValue: "") as? String;
+                        let headers = providerConf.value(forKeyPath: "headers", defaultValue: nil) as? Dictionary<String, String>
+                        soundstripeProvider = SoundstripeAudioProvider(
+                            baseURL: baseURL ?? "",
+                            headers: headers
+                        )
+                    providers.append(SoundstripeAudioClipCategory(provider: soundstripeProvider!))
+                    break
+                    case .none: return
+                    case .some(_): return
+                }
+            })
+        }
+        return providers
+    }
+    
+    private func hasAudioClipCategories(configurationData: IMGLYDictionary) -> Bool {
+        let audioClipCategoryListConf = (configurationData.value(forKeyPath: "audio", defaultValue: nil) as? Dictionary<String, Any>)?.value(forKeyPath: "categories", defaultValue: nil) as? [Dictionary<String, Any>]
+        
+        return audioClipCategoryListConf != nil && !audioClipCategoryListConf!.isEmpty
     }
 
     private func configureToolbar(_ builder: ConfigurationBuilder) {

--- a/lib/imgly_sdk.dart
+++ b/lib/imgly_sdk.dart
@@ -22,6 +22,7 @@ class Configuration {
       this.tools,
       this.transform,
       this.audio,
+      this.audioProviders,
       this.composition,
       this.trim,
       this.watermark,
@@ -33,6 +34,9 @@ class Configuration {
 
   /// Configuration options for `Tool.audio`.
   final AudioOptions? audio;
+
+  /// A list of audio providers. (Currently only Soundstripe is available)
+  final List<BasicAudioProvider>? audioProviders;
 
   /// Configuration options for `Tool.brush`.
   final BrushOptions? brush;
@@ -144,6 +148,9 @@ class Configuration {
     final jsonObject = {
       "adjustment": adjustment?._toJson(),
       "audio": audio?._toJson(),
+      "audioProviders": audioProviders == null
+          ? null
+          : List<dynamic>.from(audioProviders!.map((e) => e._toJson())),
       "brush": brush?._toJson(),
       "composition": composition?._toJson(),
       "enableZoom": enableZoom,
@@ -3541,6 +3548,45 @@ class AudioClipCategory extends _NamedItem {
     }
     return map..removeWhere((key, value) => value == null);
   }
+}
+
+/// An abstract class that represents the minimum info required to use an audio provider.
+///
+/// Note: the audio provider must be supported by IMGLY, like Soundstripe
+abstract class BasicAudioProvider {
+  BasicAudioProvider(this.identifier, this.baseURL, {this.headers});
+
+  /// The provider identifier.
+  final String identifier;
+
+  /// The audio provider base URL
+  final String baseURL;
+
+  /// The headers for the baseURL request. This should be at least an Authorization header for security purposes.
+  final Map<String, String>? headers;
+
+  /// Converts a [AudioClipCategory] for JSON parsing.
+  Map<String, dynamic> _toJson() {
+    final map = <String, dynamic>{
+      "identifier": identifier,
+      "baseURL": baseURL,
+      "headers": headers,
+    };
+    return map..removeWhere((key, value) => value == null);
+  }
+}
+
+/// A [SoundstripeAudioProvider] represents an entry point to the Soundstripe Audio API.
+class SoundstripeAudioProvider extends BasicAudioProvider {
+  /// Creates an audio provider consuming Soundstripe Audio API.
+  ///
+  /// - Parameters:
+  ///   - baseURL: The base URL of your endpoint.
+  ///   - headers: The headers for the URL request.
+  ///
+  /// - Note: The [SoundstripeAudioProvider] assumes that your endpoint is mirroring the official [Soundstripe API](https://docs.soundstripe.com).
+  SoundstripeAudioProvider(String baseURL, {Map<String, String>? headers})
+      : super('soundstripe', baseURL, headers: headers);
 }
 
 /// An audio clip.

--- a/lib/imgly_sdk.dart
+++ b/lib/imgly_sdk.dart
@@ -22,6 +22,7 @@ class Configuration {
       this.tools,
       this.transform,
       this.audio,
+      this.audioProviders,
       this.composition,
       this.trim,
       this.watermark,
@@ -34,6 +35,9 @@ class Configuration {
 
   /// Configuration options for `Tool.audio`.
   final AudioOptions? audio;
+
+  /// A list of audio providers. (Currently only Soundstripe is available)
+  final List<BasicAudioProvider>? audioProviders;
 
   /// Configuration options for `Tool.brush`.
   final BrushOptions? brush;
@@ -153,6 +157,9 @@ class Configuration {
     final jsonObject = {
       "adjustment": adjustment?._toJson(),
       "audio": audio?._toJson(),
+      "audioProviders": audioProviders == null
+          ? null
+          : List<dynamic>.from(audioProviders!.map((e) => e._toJson())),
       "brush": brush?._toJson(),
       "composition": composition?._toJson(),
       "enableZoom": enableZoom,
@@ -3531,6 +3538,45 @@ class AudioClipCategory extends _NamedItem {
     }
     return map..removeWhere((key, value) => value == null);
   }
+}
+
+/// An abstract class that represents the minimum info required to use an audio provider.
+///
+/// Note: the audio provider must be supported by IMGLY, like Soundstripe
+abstract class BasicAudioProvider {
+  BasicAudioProvider(this.identifier, this.baseURL, {this.headers});
+
+  /// The provider identifier.
+  final String identifier;
+
+  /// The audio provider base URL
+  final String baseURL;
+
+  /// The headers for the baseURL request. This should be at least an Authorization header for security purposes.
+  final Map<String, String>? headers;
+
+  /// Converts a [AudioClipCategory] for JSON parsing.
+  Map<String, dynamic> _toJson() {
+    final map = <String, dynamic>{
+      "identifier": identifier,
+      "baseURL": baseURL,
+      "headers": headers,
+    };
+    return map..removeWhere((key, value) => value == null);
+  }
+}
+
+/// A [SoundstripeAudioProvider] represents an entry point to the Soundstripe Audio API.
+class SoundstripeAudioProvider extends BasicAudioProvider {
+  /// Creates an audio provider consuming Soundstripe Audio API.
+  ///
+  /// - Parameters:
+  ///   - baseURL: The base URL of your endpoint.
+  ///   - headers: The headers for the URL request.
+  ///
+  /// - Note: The [SoundstripeAudioProvider] assumes that your endpoint is mirroring the official [Soundstripe API](https://docs.soundstripe.com).
+  SoundstripeAudioProvider(String baseURL, {Map<String, String>? headers})
+      : super('soundstripe', baseURL, headers: headers);
 }
 
 /// An audio clip.


### PR DESCRIPTION
This PR adds support to `audioProviders` on `Configuration` options, specifically supporting `SoundstripeAudioProvider`. Since `Soundstripe` integration support was added to Android and iOS native libraries back on Feb 16, I was expecting an update on flutter plugin supporting these integrations.

I understand Audio Providers support from flutter side is not an easy feature and I also understand the way I added this support could not be the ideal way, as I only modified code on `imgly-flutter` plugin code to support Soundstripe and maybe this integration should imply more modules to support other Audio Providers.

Anyway I share the code so you can check it and decide if it works for a merge as a first approach until full audio provider support can be added to flutter.


Usage would be as simple as
```dart
final configuration = Configuration(
      audioProviders: [
        SoundstripeAudioProvider(
            'https://api.soundstripe.myproxy.com',
            headers: {"Authorization": "Token XXXXXX"}
        ),
      ],
    );
```